### PR TITLE
get test code ready for Play 2.6

### DIFF
--- a/src/main/g8/test/controllers/HomeControllerTest.java
+++ b/src/main/g8/test/controllers/HomeControllerTest.java
@@ -9,6 +9,7 @@ import play.test.WithApplication;
 
 import static org.junit.Assert.assertEquals;
 import static play.mvc.Http.Status.OK;
+import static play.test.Helpers.fakeRequest;
 import static play.test.Helpers.GET;
 import static play.test.Helpers.route;
 
@@ -21,9 +22,7 @@ public class HomeControllerTest extends WithApplication {
 
     @Test
     public void testIndex() {
-        Http.RequestBuilder request = new Http.RequestBuilder()
-                .method(GET)
-                .uri("/");
+        Http.RequestBuilder request = fakeRequest(GET, "/");
 
         Result result = route(app, request);
         assertEquals(OK, result.status());


### PR DESCRIPTION
The current test does not pass in Play 2.6-M4 (but it does in 2.5.14).  This change makes it work in both Play 2.6 and 2.5.

The problem with the current code when you run it in Play 2.6 seems to be that you need to call `host("localhost")` on the `request` object if you're building it from scratch or else you get an HTTP 400 response.