### PR TITLE
[2.6.x] remove usage of interpolation variables

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -21,10 +21,15 @@ model {
     }
 }
 
+
+def dependencyFor(String lib, String scalaVersion, String version) {
+    return lib + "_" + scalaVersion + ":" + version
+} 
+
 dependencies {
-    play "com.typesafe.play:play-guice_\$scalaVersion:\$playVersion"
-    play "com.typesafe.play:play-logback_\$scalaVersion:\$playVersion"
-    play "com.typesafe.play:filters-helpers_\$scalaVersion:\$playVersion"
+    play dependencyFor("com.typesafe.play:play-guice", scalaVersion, playVersion)
+    play dependencyFor("com.typesafe.play:play-logback", scalaVersion, playVersion)
+    play dependencyFor("com.typesafe.play:filters-helpers", scalaVersion, playVersion)
 }
 
 repositories {


### PR DESCRIPTION
This PR removes the usage of interpolation variables that have been a source of issues when running TemplateControl on a Giter8 template.
