### PR TITLE
[2.8.x] coloredLevel not even used in logback config

### DIFF
--- a/src/main/g8/conf/logback.xml
+++ b/src/main/g8/conf/logback.xml
@@ -1,8 +1,6 @@
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
 <configuration>
 
-  <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
-
   <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
     <encoder>


### PR DESCRIPTION
`%highlight(%-5level)` used instead already