### PR TITLE
[3.0.x] Do not query maven for latest versions - we can use scala-steward

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -3,3 +3,5 @@ commits.message = "[3.0.x] ${artifactName} ${nextVersion} (was ${currentVersion}
 pullRequests.grouping = [
   { name = "patches", "title" = "[3.0.x] Patch updates", "filter" = [{"version" = "patch"}] }
 ]
+
+buildRoots = [ ".", "src/main/g8" ]

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -5,6 +5,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "$scala_version$"
+scalaVersion := "2.13.16"
 
 libraryDependencies += guice

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,10 +2,3 @@ description=This template generates a Play Java project
 name=play-java-seed
 organization=com.example
 verbatim=*.css *.js *.png logback.xml
-
-# We use `play-exceptions` artifact as undependend of Scala version
-# just to find the latest version of Play in Maven Central
-play_version = maven(org.playframework, play-exceptions, stable)
-scala_version = maven(org.scala-lang, scala-library, stable)
-# We use `giter8_2.13` to find the latest version of sbt-giter8-scaffold_2.12_1.0
-sbt_giter8_scaffold_version = maven(org.foundweekends.giter8, giter8_2.13)

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,7 +1,7 @@
 // The Play plugin
-addSbtPlugin("org.playframework" % "sbt-plugin" % "$play_version$")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.7")
 
 // Defines scaffolding (found under .g8 folder)
 // http://www.foundweekends.org/giter8/scaffolding.html
 // sbt "g8Scaffold form"
-addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "$sbt_giter8_scaffold_version$")
+addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.17.0")


### PR DESCRIPTION
Works around
- https://github.com/foundweekends/giter8/issues/963
- https://github.com/sbt/sbt/issues/8144

Instead of using the `maven(...)` functions we just hardcode the versions and let scala-steward handle the updates.
I was showing Play to someone at a conference two weeks ago and it was very embarrasing that I could not even run `sbt new` and choosing the play templates (and instead seeing an error)...

I also tested this to make sure scala-steward really updates the versions in the `src/main/g8/` folder:
- https://github.com/mkurz/play-java-seed.g8/pulls?q=is%3Apr (the PR's are now incorrect because I force pushed afterwards)

I had to add it as a build root. This is necessary because according to [the scala steward FAQs](https://github.com/scala-steward-org/scala-steward/blob/v0.34.0/docs/faq.md#can-scala-steward-update-dependencies-in-giter8-templates-)

> *Scala Steward can update versions in giter8 templates if the dependencies of the template are also added as dependencies of the template build.*

But we do not have the scalaVersion or the play sbt-plugin in the root project, so they will not be updated in `src/main/g8/` (I was actually testing that with my repo as well and can confirm scala-steward did not update anything).

Another approach would be to add a no-op project in the root `build.sbt` and define the dependencies that need to be updated in `src/main/g8/` - however if the `buildRoots` config works I do not see the advantage (we might miss dependencies in the future). However, Disney is doing it this way, see
- https://github.com/disneystreaming/smithy4s.g8/pull/43/files

Also here a discussion in the scala-steward repo:
- https://github.com/scala-steward-org/scala-steward/issues/1286 (they do not really support giter8 explicitly)