### PR TITLE
[2.8.x] Do not query maven for latest versions

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -5,6 +5,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "$scala_version$"
+scalaVersion := "2.13.16"
 
 libraryDependencies += guice

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,8 +2,3 @@ description = This template generates a Play Java project
 name = play-java-seed
 organization=com.example
 verbatim=*.css *.js *.png logback.xml
-
-# We use `play-exceptions` artifact as undependend of Scala version
-# just to find the latest version of Play in Maven Central
-play_version = maven(com.typesafe.play, play-exceptions, stable)
-scala_version = maven(org.scala-lang, scala-library, stable)

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "$play_version$")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.22")
 
 // Defines scaffolding (found under .g8 folder)
 // http://www.foundweekends.org/giter8/scaffolding.html


### PR DESCRIPTION
I know 2.8.x is EOL.
Funny thing however is I tried to reproduce an problem in Play 2.8 (to see if it worked before Play 2.9) and when running
```
sbt new playframework/play-java-seed.g8 --branch 2.8.x
```

it queried for the latest version of the `com.typesafe.play:play-exceptions` maven artifacted which results in `play_version [2.9.7]: ...` which also gets of course written into `project/plugins.sbt`.

- Related to #204