### PR TITLE
Add a Mill build script

### DIFF
--- a/src/main/g8/build.mill
+++ b/src/main/g8/build.mill
@@ -1,0 +1,15 @@
+//| mill-version: 1.1.7
+//| mvnDeps: ["com.lihaoyi::mill-contrib-playlib:$MILL_VERSION"]
+package build
+
+import mill.*
+import mill.playlib.*
+
+object `package` extends PlayModule {
+
+  override def scalaVersion = Task { "2.13.18" }
+  override def playVersion = Task { "3.0.11" }
+  override def twirlVersion = Task { "2.0.9" }
+
+  object test extends PlayTests
+}

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,4 +1,4 @@
 description=This template generates a Play Java project
 name=play-java-seed
 organization=com.example
-verbatim=*.css *.js *.png logback.xml
+verbatim=*.css *.js *.png logback.xml build.mill


### PR DESCRIPTION
## Summary
Since `playframework/play-scala-seed.g8` has been [updated to support Mill 1.x](https://github.com/playframework/play-scala-seed.g8/pull/352), this PR introduces Mill build tool support to the current repository. 

## Key Changes
The `build.mill` script is largely identical to the upstream version, with two main differences:
1. **Explicit `mill-version` Configuration:** The `mill-version` is explicitly set in the build.
2. **Giter8 `verbatim` Configuration:** Instead of using `phantomDeps`, the `build.mill` file is simply added to the Giter8 `verbatim` list.

## Rationale & Design Decisions

### 1. Explicit `mill-version`
Explicitly defining the `mill-version` is considered the better approach. Scala Steward should be fully capable of detecting and managing this version number automatically, just as it currently does for `sbt.version`.

### 2. Avoiding `phantomDeps` and `$` Escaping Issues
Adding `build.mill` to the `verbatim` list bypasses the parsing confusion caused by the backslash-dollar (`\$`) escape sequence for both Scala Steward and Mill. 
Conveniently, since `build.mill` now strictly accepts `package` as the `RootModule` name, we no longer need to engineer complex workarounds for Giter8 to process it dynamically.

## Future Work
If this approach proves successful and stable here, these two modifications can and should be contributed back to `playframework/play-scala-seed.g8`.